### PR TITLE
Use source published date instead of sync date in feed

### DIFF
--- a/alembic/versions/i8j1k6l7m8n9_add_published_to_user_feed_items.py
+++ b/alembic/versions/i8j1k6l7m8n9_add_published_to_user_feed_items.py
@@ -1,0 +1,25 @@
+"""Add published column to user_feed_items.
+
+Revision ID: i8j1k6l7m8n9
+Revises: h7i0j5k6l7m8
+Create Date: 2026-01-29
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "i8j1k6l7m8n9"
+down_revision = "h7i0j5k6l7m8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("user_feed_items", sa.Column("published", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("user_feed_items", "published")

--- a/src/model/user_feed.py
+++ b/src/model/user_feed.py
@@ -43,6 +43,7 @@ class UserFeedItem(Base):
     points: Mapped[int] = mapped_column(default=0)
     views: Mapped[int] = mapped_column(default=0)
     rank_score: Mapped[float] = mapped_column(default=0.0)
+    published: Mapped[datetime | None] = mapped_column(default=None)
 
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(server_default=func.now(), onupdate=func.now())

--- a/src/repository/feed_storage.py
+++ b/src/repository/feed_storage.py
@@ -126,6 +126,7 @@ class FeedStorage:
             summary=item.summary,
             rank_score=item.rank_score,
             state=item_state,
+            published=item.published,
             created_at=item.created_at,
             updated_at=item.updated_at,
         )

--- a/src/schemas/feeds.py
+++ b/src/schemas/feeds.py
@@ -72,6 +72,7 @@ class UserFeedItemIn(BaseModel):
     views: int | None = None
     summary: str | None = None
     rank_score: float = 0.0
+    published: datetime | None = None
     created_at: datetime | None = None
 
 
@@ -94,6 +95,7 @@ class UserFeedItemOut(BaseModel):
     summary: str | None = None
     rank_score: float = 0.0
     state: ItemState
+    published: datetime | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/src/service/feed_service.py
+++ b/src/service/feed_service.py
@@ -330,6 +330,7 @@ class FeedService:
                 points=item.points,
                 summary=item.summary,
                 views=item.views,
+                published=item.published,
             )
             for item in active_feed.user_feed_items
             if not item.state.read
@@ -380,5 +381,6 @@ class FeedService:
             points=item.points,
             views=item.views,
             summary=item.summary,
+            published=item.published,
             created_at=item.created_at,
         )

--- a/web/src/components/feed/FeedCard.tsx
+++ b/web/src/components/feed/FeedCard.tsx
@@ -133,10 +133,10 @@ export const FeedCard = forwardRef<HTMLDivElement, FeedCardProps>(function FeedC
       {/* Source + Time */}
       <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
         <span className="font-medium text-foreground/60">{item.source_name}</span>
-        {item.created_at && (
+        {(item.published || item.created_at) && (
           <>
             <span>·</span>
-            <span>{formatRelativeTime(item.created_at)}</span>
+            <span>{formatRelativeTime(item.published ?? item.created_at)}</span>
           </>
         )}
       </div>

--- a/web/src/pages/FeedPage.tsx
+++ b/web/src/pages/FeedPage.tsx
@@ -35,7 +35,8 @@ function getStoredBoolean(key: string, defaultValue: boolean): boolean {
 }
 
 function getDateValue(item: FeedItem): number {
-  return item.created_at ? new Date(item.created_at).getTime() : 0
+  const date = item.published ?? item.created_at
+  return date ? new Date(date).getTime() : 0
 }
 
 function sortItems(items: FeedItem[], sortBy: SortOption): FeedItem[] {
@@ -91,6 +92,7 @@ function toFeedItem(item: SearchResultItem): FeedItem {
     views: item.views,
     rank_score: 0,
     state: { ...item.state },
+    published: item.published,
     created_at: item.created_at,
     updated_at: item.updated_at,
   }

--- a/web/src/types/feed.ts
+++ b/web/src/types/feed.ts
@@ -12,6 +12,7 @@ export interface FeedItem {
   views: number | null
   rank_score: number
   state: FeedItemState
+  published: string | null
   created_at: string | null
   updated_at: string | null
 }
@@ -128,6 +129,7 @@ export interface DigestItem {
   views: number | null
   summary: string | null
   rank_score: number
+  published: string | null
   created_at: string | null
 }
 


### PR DESCRIPTION
Adds the `published` field from FeedItem through the full pipeline
(UserFeedItem model, schemas, storage, service) to the frontend,
where it is now preferred over `created_at` for display and sorting.

https://claude.ai/code/session_015CoPNarfKRMXdF387BYVpu